### PR TITLE
RSPY-850 - Remove space characters when requesting several OData values

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 default_language_version:
-    python: python3.11
+    python: python3
 default_stages: [commit]
 repos:
 # basic verifications

--- a/src/CADIP/cadip_station_mock.py
+++ b/src/CADIP/cadip_station_mock.py
@@ -256,7 +256,7 @@ def manage_satellite_sid_query(op, value, catalog_data, field, headers):
         case "eq":
             query_result = [product for product in catalog_data["Data"] if value == product[field]]
         case "in":
-            sat_sid_match = re.sub(r"[()]", "", value).split(", ")
+            sat_sid_match = re.sub(r"[()]", "", value).split(",")
             query_result = [
                 [product for product in catalog_data["Data"] if product[field] == sat_sid.strip()]
                 for sat_sid in sat_sid_match
@@ -533,8 +533,9 @@ def process_files_request(request, headers, catalog_data):
                 matching = [product for product in catalog_data["Data"] if value[0].strip("('),") == product[field]]
             case "in":
                 matching = []
-                for idx in value:
-                    matching += [product for product in catalog_data["Data"] if idx.strip("('),") in product[field]]
+                for idx_list in value:
+                    for idx in idx_list.split(","):
+                        matching += [product for product in catalog_data["Data"] if idx.strip("(')") in product[field]]
         return (
             Response(response=batch_response_odata_v4(matching), status=HTTPStatus.OK, headers=headers)
             if matching

--- a/src/LTA/lta_station_mock.py
+++ b/src/LTA/lta_station_mock.py
@@ -219,8 +219,9 @@ def process_query_request(request: str, catalog_data: dict) -> Response:
             case "eq":
                 matching = [product for product in catalog_data["Data"] if value[0] == product[field]]
             case "in":
-                for idx in value:
-                    matching += [product for product in catalog_data["Data"] if idx.replace(",", "") in product[field]]
+                for idx_list in value:
+                    for idx in idx_list.split(","):
+                        matching += [product for product in catalog_data["Data"] if idx in product[field]]
         return (
             Response(response=batch_response_odata_v4(matching), status=HTTP_OK)
             if matching

--- a/tests/test_cadip_station_mock.py
+++ b/tests/test_cadip_station_mock.py
@@ -1,10 +1,11 @@
 """Docstring to be added."""
-import base64
 import filecmp
 import json
 import os
-import pytest
 from http import HTTPStatus
+
+import pytest
+
 
 @pytest.mark.unit
 def test_basic_auth(cadip_client, external_auth_config, app_header):
@@ -12,21 +13,24 @@ def test_basic_auth(cadip_client, external_auth_config, app_header):
     data_to_send = external_auth_config
 
     # ----------- Test if we can get new credentials by providing valid authentication configuration
-    token_response = cadip_client.post("/oauth2/token", data=data_to_send, headers = app_header)
+    token_response = cadip_client.post("/oauth2/token", data=data_to_send, headers=app_header)
     assert token_response.status_code == HTTPStatus.OK
     token_info = json.loads(token_response.text)
     assert token_info["access_token"]
-    
+
     # ----------- Test if the new credentials are valid on get method
     # test credentials on get methods with auth required.
     hello_response = cadip_client.get("/", headers={"Authorization": f"Token {token_info['access_token']}"})
     assert hello_response.status_code == HTTPStatus.OK
-    
+
     # ----------- Test if the new credentials are valid on get method
     wrong_token_info = token_info.copy()
     wrong_token_info["access_token"] = "WrongAccessToken"
-    assert cadip_client.get("/", headers={"Authorization": f"Token {wrong_token_info['access_token']}"}).status_code == HTTPStatus.UNAUTHORIZED
-    
+    assert (
+        cadip_client.get("/", headers={"Authorization": f"Token {wrong_token_info['access_token']}"}).status_code
+        == HTTPStatus.UNAUTHORIZED
+    )
+
     # ----------- Test a broken endpoint route
     assert cadip_client.get("incorrectRoute/").status_code == HTTPStatus.NOT_FOUND
 
@@ -55,16 +59,15 @@ def test_basic_auth(cadip_client, external_auth_config, app_header):
                 "DownlinkStart": "2020-01-05T07:22:04.051Z",
                 "DownlinkStop": "2020-01-05T07:42:04.051Z",
                 "DownlinkStatusOK": True,
-                "DeliveryPushOK": True
+                "DeliveryPushOK": True,
             }
         ),
     ],
 )
 def test_query_sessions(cadip_client_with_auth, session_response20230216):
     """Docstring to be added."""
-    
     # test without args
-    assert cadip_client_with_auth.get("Sessions").status_code == HTTPStatus.OK # Should return all sessions
+    assert cadip_client_with_auth.get("Sessions").status_code == HTTPStatus.OK  # Should return all sessions
     # test with an incorrect filter
     assert cadip_client_with_auth.get("Sessions?$filter=Incorrect_filter").status_code == HTTPStatus.BAD_REQUEST
     # Response containing more than 1 result, since there are more products matching
@@ -75,8 +78,8 @@ def test_query_sessions(cadip_client_with_auth, session_response20230216):
     assert isinstance(json.loads(response.text), dict)
     # Check response content with test-defined one.
     response = cadip_client_with_auth.get("Sessions?$filter=PublicationDate eq 2020-01-05T18:52:26.165Z")
-    assert json.loads(response.text)['value'][0].keys() == session_response20230216.keys()
-    assert json.loads(response.text)['value'][0] == session_response20230216
+    assert json.loads(response.text)["value"][0].keys() == session_response20230216.keys()
+    assert json.loads(response.text)["value"][0] == session_response20230216
     # Empty json response since there are no products older than 1999.
     response = cadip_client_with_auth.get("Sessions?$filter=PublicationDate lt 1999-01-01T12:00:00.000Z")
     assert bool(response.text)
@@ -87,12 +90,14 @@ def test_query_sessions(cadip_client_with_auth, session_response20230216):
     # Test with sattelite - neg
     # Test status code - 200 HTTPStatus.OK, test that reponse is empty as per ICD
     assert cadip_client_with_auth.get("Sessions?$filter=Satellite eq INCORRECT").status_code == HTTPStatus.OK
-    assert cadip_client_with_auth.get("Sessions?$filter=Satellite eq INCORRECT").get_data() == b'[]'
+    assert cadip_client_with_auth.get("Sessions?$filter=Satellite eq INCORRECT").get_data() == b"[]"
     # Test with Downlink - pos - status 200 and valid content
     assert cadip_client_with_auth.get("Sessions?$filter=DownlinkOrbit eq 53186").status_code == HTTPStatus.OK
     assert len(cadip_client_with_auth.get("Sessions?$filter=DownlinkOrbit eq 53186").get_data().decode())
     # Test with Downlink - neg - status 200 and invalid content
-    assert cadip_client_with_auth.get("Sessions?$filter=DownlinkOrbit eq INCORRECT").status_code == HTTPStatus.BAD_REQUEST
+    assert (
+        cadip_client_with_auth.get("Sessions?$filter=DownlinkOrbit eq INCORRECT").status_code == HTTPStatus.BAD_REQUEST
+    )
     assert not len(cadip_client_with_auth.get("Sessions?$filter=DownlinkOrbit eq INCORRECT").get_data().decode())
     # Test with aditional filtering operator <<AND>>
     query = (
@@ -105,27 +110,27 @@ def test_query_sessions(cadip_client_with_auth, session_response20230216):
     assert cadip_client_with_auth.get(query).status_code == HTTPStatus.OK
     assert len(cadip_client_with_auth.get(query).get_data().decode())
     # Test with 3 valid filters
-    query = "Sessions?$filter=Satellite in ('S1A', 'S2B') and PublicationDate gt 2014-03-12T08:00:00.000Z and PublicationDate lt 2024-03-12T12:00:00.000Z"
+    query = "Sessions?$filter=Satellite in ('S1A','S2B') and PublicationDate gt 2014-03-12T08:00:00.000Z and PublicationDate lt 2024-03-12T12:00:00.000Z"
     assert cadip_client_with_auth.get(query).status_code == HTTPStatus.OK
     # Incorrect downlink, status HTTPStatus.OK but empty result
     query = "Sessions?$filter=DownlinkOrbit eq '53186' and PublicationDate gt 2014-03-12T08:00:00.000Z and PublicationDate lt 2024-03-12T12:00:00.000Z"
     assert cadip_client_with_auth.get(query).status_code == HTTPStatus.OK
-    #@@@assert not json.loads(cadip_client.get(query, headers=auth_header).text)
+    # @@@assert not json.loads(cadip_client.get(query, headers=auth_header).text)
     # Test with 2 valid filters and 1 invalid, should raise 404 not found
     query = "Sessions?$filter=Satellite eq 'S3' and PublicationDate gt 2014-03-12T08:00:00.000Z and PublicationDate lt 2024-03-12T12:00:00.000Z"
     assert cadip_client_with_auth.get(query).status_code == HTTPStatus.OK
-    assert json.loads(cadip_client_with_auth.get(query).text)['value'] == []
+    assert json.loads(cadip_client_with_auth.get(query).text)["value"] == []
     # Test with sattelite in (invalid, valid) and 2 other filters valid
-    query = "Sessions?$filter=Satellite in ('S1', invalid) and PublicationDate gt 2014-03-12T08:00:00.000Z and PublicationDate lt 2024-03-12T12:00:00.000Z"
+    query = "Sessions?$filter=Satellite in ('S1',invalid) and PublicationDate gt 2014-03-12T08:00:00.000Z and PublicationDate lt 2024-03-12T12:00:00.000Z"
     assert cadip_client_with_auth.get(query).status_code == HTTPStatus.OK
-    assert json.loads(cadip_client_with_auth.get(query).text)['value'] == []
-    query = "Sessions?$filter=Satellite in ('invalid', invalid) and PublicationDate gt 2014-03-12T08:00:00.000Z and PublicationDate lt 2024-03-12T12:00:00.000Z"
+    assert json.loads(cadip_client_with_auth.get(query).text)["value"] == []
+    query = "Sessions?$filter=Satellite in ('invalid',invalid) and PublicationDate gt 2014-03-12T08:00:00.000Z and PublicationDate lt 2024-03-12T12:00:00.000Z"
     assert cadip_client_with_auth.get(query).status_code == HTTPStatus.OK
-    assert json.loads(cadip_client_with_auth.get(query).text)['value'] == []
+    assert json.loads(cadip_client_with_auth.get(query).text)["value"] == []
     # Test with 2 invalid date filters
-    query = "Sessions?$filter=Satellite in ('S1', invalid) and PublicationDate gt 2025-03-12T08:00:00.000Z and PublicationDate lt 2030-03-12T12:00:00.000Z"
+    query = "Sessions?$filter=Satellite in ('S1',invalid) and PublicationDate gt 2025-03-12T08:00:00.000Z and PublicationDate lt 2030-03-12T12:00:00.000Z"
     assert cadip_client_with_auth.get(query).status_code == HTTPStatus.OK
-    assert not json.loads(cadip_client_with_auth.get(query).text)['value']
+    assert not json.loads(cadip_client_with_auth.get(query).text)["value"]
     # Test with incorrect filter
     query = "Sessions?$filter=IncorrectField eq true"
     assert cadip_client_with_auth.get(query).status_code == HTTPStatus.BAD_REQUEST
@@ -137,11 +142,11 @@ def test_query_sessions(cadip_client_with_auth, session_response20230216):
     assert cadip_client_with_auth.get(query).status_code == HTTPStatus.OK
     # Eodagspecific request tests
     dag_filter = [
-        "SessionId%20in%20('S2B_20231117033237234567,%20S1A_20231120061537234567%20&$top=20",
+        "SessionId%20in%20('S2B_20231117033237234567','S1A_20231120061537234567'&$top=20",
         "SessionId%20in%20('S1A_20231120061537234567')%20&$top=20",
         "SessionId%20in%20('S1A_20231120061537234567')%20and%20Satellite%20in%20('S1A')%22&$top=20",
-        "SessionId in ('S1A_20231120061537234567', 'S2B_20231117033237234567') and Satellite in ('S1A', 'S2B')&$top=20&$expand=Files"
-    ] 
+        "SessionId in ('S1A_20231120061537234567','S2B_20231117033237234567') and Satellite in ('S1A','S2B')&$top=20&$expand=Files",
+    ]
     for query in dag_filter:
         endpoint = f"Sessions?$filter={query}"
         assert cadip_client_with_auth.get(endpoint).status_code == HTTPStatus.OK
@@ -150,13 +155,16 @@ def test_query_sessions(cadip_client_with_auth, session_response20230216):
     time_filters = [
         "Sessions?$filter=PublicationDate eq 2020-01-05T18:52:26.165Z",
         "Sessions?$filter=PublicationDate lte 2020-01-05T18:52:26.165Z",
-        "Sessions?$filter=PublicationDate gte 2020-01-05T18:52:26.165Z"
+        "Sessions?$filter=PublicationDate gte 2020-01-05T18:52:26.165Z",
     ]
     for query in time_filters:
         resp = cadip_client_with_auth.get(query)
         assert resp.status_code == HTTPStatus.OK
         resp_data = json.loads(resp.text)
-        assert ("value" in resp_data and session_response20230216 in resp_data["value"]) or resp_data == json.loads(resp.text)
+        assert ("value" in resp_data and session_response20230216 in resp_data["value"]) or resp_data == json.loads(
+            resp.text,
+        )
+
 
 @pytest.mark.unit
 def test_query_files(cadip_client_with_auth):
@@ -189,20 +197,20 @@ def test_query_files(cadip_client_with_auth):
     top_pagination_nr = "3"
     query = f'Files?$top={top_pagination_nr}&$filter="PublicationDate%20gt%202014-01-01T12:00:00.000Z%20and%20PublicationDate%20lt%202023-12-30T12:00:00.000Z'
     data = cadip_client_with_auth.get(query)
-    assert len(json.loads(data.text)['value']) == int(top_pagination_nr)
+    assert len(json.loads(data.text)["value"]) == int(top_pagination_nr)
     assert cadip_client_with_auth.get(query).status_code == HTTPStatus.OK
     # Test top pagination element, this query should return 10 elements, top should display only first 3. filter&top
     top_pagination_nr = "3"
     query = f'Files?$filter="PublicationDate%20gt%202014-01-01T12:00:00.000Z%20and%20PublicationDate%20lt%202023-12-30T12:00:00.000Z&$top={top_pagination_nr}'
     data = cadip_client_with_auth.get(query)
-    assert len(json.loads(data.text)['value']) == int(top_pagination_nr)
+    assert len(json.loads(data.text)["value"]) == int(top_pagination_nr)
     assert cadip_client_with_auth.get(query).status_code == HTTPStatus.OK
 
     # Test skip pagination element, this query should return 201 elements, skip should display only 194. (07.06.24 update)
     skip_pagination_nr = "7"
     query = f'Files?$skip={skip_pagination_nr}&$filter="PublicationDate%20gt%202014-01-01T12:00:00.000Z%20and%20PublicationDate%20lt%202023-12-30T12:00:00.000Z'
     data = cadip_client_with_auth.get(query)
-    assert len(json.loads(data.text)['value']) == 201 - int(skip_pagination_nr)
+    assert len(json.loads(data.text)["value"]) == 201 - int(skip_pagination_nr)
     assert cadip_client_with_auth.get(query).status_code == HTTPStatus.OK
 
 
@@ -215,10 +223,7 @@ def test_query_quality_info():
     "local_path, download_path",
     [
         # to be changed after deploy / pipeline
-        (
-            ("tests/data/", "S1A.raw"),
-            ("tests/S3MockTest/", "S1A_test.raw")
-        ),
+        (("tests/data/", "S1A.raw"), ("tests/S3MockTest/", "S1A_test.raw")),
     ],
 )
 def test_download_file(cadip_client_with_auth, local_path, download_path):
@@ -261,13 +266,12 @@ def test_expand(cadip_client_with_auth):
     assert cadip_client_with_auth.get(endpoint).status_code == HTTPStatus.OK
     assert json.loads(cadip_client_with_auth.get(endpoint).text)
     # Check that the "Files" list is not empty
-    assert len(json.loads(cadip_client_with_auth.get(endpoint).text)["value"][0]['Files'])
-
+    assert len(json.loads(cadip_client_with_auth.get(endpoint).text)["value"][0]["Files"])
 
     # Test with a complex query that returns multiple expanded sessions
     endpoint = "Sessions?$filter=DownlinkOrbit eq '53186' and PublicationDate gt 2014-03-12T08:00:00.000Z and PublicationDate lt 2024-03-12T12:00:00.000Z&$expand=files"
     assert cadip_client_with_auth.get(endpoint).status_code == HTTPStatus.OK
     assert json.loads(cadip_client_with_auth.get(endpoint).text)
     # Check that each sessions files list is not empty
-    for session in json.loads(cadip_client_with_auth.get(endpoint).text)['value']:
-        assert len(session['Files'])
+    for session in json.loads(cadip_client_with_auth.get(endpoint).text)["value"]:
+        assert len(session["Files"])


### PR DESCRIPTION
PRIP S3A does not accept requests containing the "in" operator with space characters.

This PR make the mocks accept OData requests without space character.

Pull requests:
- https://github.com/RS-PYTHON/rs-server/pull/1557
- https://github.com/RS-PYTHON/rs-testmeans/pull/62