### PR TITLE
RSPY-1108: Problems in the CI/CD to build the Jupyter docker images

### DIFF
--- a/.github/workflows/publish-binaries.yml
+++ b/.github/workflows/publish-binaries.yml
@@ -29,8 +29,8 @@ on:
           - rs-testmeans
           - rebuild-base-dask # called by rs-workflow-env after rebuilding the base dask images
         default: rs-testmeans
-      docker_tag:
-        description: Add this tag to the docker images as e.g. 'latest' or 'feat-rspy123'
+      add_docker_tags:
+        description: Add these tags to the docker images as e.g. 'custom-tag1,custom-tag-2'
         required: false
 
 env:
@@ -49,8 +49,8 @@ jobs:
       - id: build_version_name
         run: echo "version_name=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
-  set-env:
-    name: Set environment
+  set-binary-env:
+    name: Set Docker environment
     if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     needs: build_version_name
@@ -61,16 +61,16 @@ jobs:
     steps:
       - id: set-binary-env
         name: Call action 'set-binary-env'
-        uses: RS-PYTHON/actions/.github/actions/set-binary-env@develop
+        uses: RS-PYTHON/actions/.github/actions/set-binary-env@feat-rspy1108/jupyter-cicd
         with:
           wheel_version_name: ${{ needs.build_version_name.outputs.version_name }}
-          manual_tag: ${{ github.event.inputs.docker_tag }}
+          add_docker_tags: ${{ inputs.add_docker_tags }}
 
   publish-docker-images:
     name: "Build and publish Docker images"
     runs-on: ubuntu-latest
     if: github.actor != 'dependabot[bot]'
-    needs: set-env
+    needs: set-binary-env
     permissions:
       security-events: write # needed for github/codeql-action/upload-sarif
       packages: write # needed for 'docker push'
@@ -148,7 +148,7 @@ jobs:
           build_context_path: ${{ matrix.build_context_path }}
           image_basename: ${{ matrix.image_basename }}
           image_suffix: ${{ matrix.image_suffix }}
-          image_tags: ${{ needs.set-env.outputs.docker_tags }}
+          image_tags: ${{ needs.set-binary-env.outputs.docker_tags }}
           dockerhub_username: ${{ vars.DOCKERHUB_USERNAME }}
           dockerhub_token: ${{ secrets.DOCKERHUB_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -163,19 +163,19 @@ jobs:
 
   get-pushed-images:
     name: Get pushed Docker image names
-    needs: [set-env, publish-docker-images]
+    needs: [set-binary-env, publish-docker-images]
     if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     outputs:
       pushed_images: ${{ steps.read.outputs.pushed_images }}
     steps:
       - id: read-matrix-outputs
-        if: ${{ needs.set-env.outputs.docker_final_tags != '' }} # only if a temp Docker tag has been set
+        if: ${{ needs.set-binary-env.outputs.docker_final_tags != '' }} # only if a temp Docker tag has been set
         uses: cloudposse/github-action-matrix-outputs-read@ddb62566e896c85614f5eeec2daa43d6d1dc6cb0
         with:
             matrix-step-name: publish-docker-images
       - id: read
-        if: ${{ needs.set-env.outputs.docker_final_tags != '' }}
+        if: ${{ needs.set-binary-env.outputs.docker_final_tags != '' }}
         run: |
           set -x
           # Docker images that have been pushed
@@ -190,7 +190,7 @@ jobs:
     name: Test rs-demo
     if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
-    needs: [set-env, publish-docker-images, get-pushed-images]
+    needs: [set-binary-env, publish-docker-images, get-pushed-images]
     permissions:
      packages: write # needed for 'docker push'
     steps:
@@ -203,8 +203,8 @@ jobs:
 
       - name: Test rs-demo
         env:
-          BRANCH_NAME: ${{ needs.set-env.outputs.branch_name }}
-          DOCKER_TAGS: ${{ needs.set-env.outputs.docker_tags }}
+          BRANCH_NAME: ${{ needs.set-binary-env.outputs.branch_name }}
+          DOCKER_TAGS: ${{ needs.set-binary-env.outputs.docker_tags }}
         run: |
           set -x
 
@@ -221,9 +221,9 @@ jobs:
       # If we used a temp docker tag, and only if the tests succeeded, then
       # we tag the images with the real tags and push them.
       - name: Tag and push Docker images
-        if: ${{ needs.set-env.outputs.docker_final_tags != '' }}
+        if: ${{ needs.set-binary-env.outputs.docker_final_tags != '' }}
         uses: RS-PYTHON/actions/.github/actions/tag-push-docker@feat-rspy1108/jupyter-cicd
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           old_docker_images: ${{ needs.get-pushed-images.outputs.pushed_images }}
-          new_tags: ${{ needs.set-env.outputs.docker_final_tags }}
+          new_tags: ${{ needs.set-binary-env.outputs.docker_final_tags }}

--- a/.github/workflows/publish-binaries.yml
+++ b/.github/workflows/publish-binaries.yml
@@ -32,6 +32,12 @@ on:
       add_docker_tags:
         description: Add these tags to the docker images as e.g. 'custom-tag1,custom-tag-2'
         required: false
+      force_docker_tags:
+        description: If set, force these docker tags (used when called from other repository)
+        required: false
+      force_docker_final_tags:
+        description: If set, force these final docker tags (used when called from other repository)
+        required: false
 
 env:
   DOCKER_REGISTRY: ghcr.io
@@ -65,6 +71,8 @@ jobs:
         with:
           wheel_version_name: ${{ needs.build_version_name.outputs.version_name }}
           add_docker_tags: ${{ inputs.add_docker_tags }}
+          force_docker_tags: ${{ inputs.force_docker_tags }}
+          force_docker_final_tags: ${{ inputs.force_docker_final_tags }}
 
   publish-docker-images:
     name: "Build and publish Docker images"

--- a/.github/workflows/publish-binaries.yml
+++ b/.github/workflows/publish-binaries.yml
@@ -23,17 +23,15 @@ on:
     tags: ['**'] # new git tags (including hierarchical tags like v1.0/beta)
   workflow_dispatch: # manual trigger
     inputs:
+      called_by:
+        type: choice
+        options:
+          - rs-testmeans
+          - rebuild-base-dask # called by rs-workflow-env after rebuilding the base dask images
+        default: rs-testmeans
       docker_tag:
         description: Add this tag to the docker images as e.g. 'latest' or 'feat-rspy123'
         required: false
-      build_only_mockup_images:
-        description: Put to true to only build the images for DPR processor mockup
-        required: false
-        default: 'false'
-        type: choice
-        options:
-          - 'true'
-          - 'false'
 
 env:
   DOCKER_REGISTRY: ghcr.io
@@ -88,23 +86,23 @@ jobs:
 
         # Options specific to each image, from the publish-docker action.
         include:
-          - if: success() && !cancelled() # default value
-
           - image: adgs
-            if: ${{ github.event.inputs.build_only_mockup_images != 'true' }}
+            if: ${{ contains('rs-testmeans', inputs.called_by) }} # If called by rs-testmeans
             dockerfile: ./src/ADGS/Dockerfile
             build_context_path: ./src
             image_basename: ${{ github.repository }} # rs-python/rs-testmeans
             image_suffix: _adgs-station-mock
 
           - image: cadip
-            if: ${{ github.event.inputs.build_only_mockup_images != 'true' }}
+            if: ${{ contains('rs-testmeans', inputs.called_by) }} # If called by rs-testmeans
             dockerfile: ./src/CADIP/Dockerfile
             build_context_path: ./src
             image_basename: ${{ github.repository }} # rs-python/rs-testmeans
             image_suffix: _cadip-station-mock
 
           - image: dask-mockup-k8s # dask image for mockup dpr processor, cluster mode
+            # If called by rs-testmeans or after rebuilding the base dask images
+            if: ${{ contains('rs-testmeans,rebuild-base-dask', inputs.called_by) }}
             dockerfile: ./src/DPR/Dockerfile.dask-eopf-mockup
             build_context_path: ./src/DPR
             image_basename: ${{ github.repository_owner }}/dask/mockup # rs-python/dask/mockup
@@ -112,6 +110,8 @@ jobs:
             build_args: "BASE_IMAGE_TARGET=k8s"
 
           - image: dask-mockup-local # dask image for mockup dpr processor, local mode
+            # If called by rs-testmeans or after rebuilding the base dask images
+            if: ${{ contains('rs-testmeans,rebuild-base-dask', inputs.called_by) }}
             dockerfile: ./src/DPR/Dockerfile.dask-eopf-mockup
             build_context_path: ./src/DPR
             image_basename: ${{ github.repository_owner }}/dask/mockup # rs-python/dask/mockup
@@ -119,14 +119,14 @@ jobs:
             build_args: "BASE_IMAGE_TARGET=local"
 
           - image: lta
-            if: ${{ github.event.inputs.build_only_mockup_images != 'true' }}
+            if: ${{ contains('rs-testmeans', inputs.called_by) }} # If called by rs-testmeans
             dockerfile: ./src/LTA/Dockerfile
             build_context_path: ./src/LTA
             image_basename: ${{ github.repository }} # rs-python/rs-testmeans
             image_suffix: _lta-station-mock
 
           - image: prip
-            if: ${{ github.event.inputs.build_only_mockup_images != 'true' }}
+            if: ${{ contains('rs-testmeans', inputs.called_by) }} # If called by rs-testmeans
             dockerfile: ./src/PRIP/Dockerfile
             build_context_path: ./src
             image_basename: ${{ github.repository }} # rs-python/rs-testmeans
@@ -222,7 +222,8 @@ jobs:
       # we tag the images with the real tags and push them.
       - name: Tag and push Docker images
         if: ${{ needs.set-env.outputs.docker_final_tags != '' }}
-        uses: RS-PYTHON/actions/.github/actions/tag-push-docker@develop
+        uses: RS-PYTHON/actions/.github/actions/tag-push-docker@feat-rspy1108/jupyter-cicd
         with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           old_docker_images: ${{ needs.get-pushed-images.outputs.pushed_images }}
           new_tags: ${{ needs.set-env.outputs.docker_final_tags }}


### PR DESCRIPTION
How these changes fix the Jira https://pforge-exchange2.astrium.eads.net/jira/browse/RSPY-1108: 

  * The docker tag for the jupyter base image is not `hub-xxx-pyzzz-vn` anymore, but instead it is the branch name. So we don't have any more conflicts between branches. (fixes problem 1)
  * The jupyter image for cluster mode (built by rs-workflow-env) needs the rs-client-libraries wheel. Instead of downloading it from the rs-client-libraries repository ci/cd, it now checkouts the rs-client-libraries source code and builds the wheel itself. This way, the rs-client-libraries ci/cd does not have to trigger the rs-workflow-env ci/cd anymore. (fixes problem 2)
  * After rs-workflow-env builds the base jupyter image, now it triggers the rs-client-libraries ci/cd to build the jupyter image for local mode. (fixes problem 2)
    * If rs-client-libraries does not have the same branch name as in rs-workflow-env, then the develop branch of rs-client-libraries is triggered, but we tell it to use the docker tags with the same branch name as rs-workflow-env. See `force_docker_tags` and `force_docker_final_tags`. (fixes problem 3)

About the comment
> So maybe the rs-workflow-env ci/cd should always trigger the rs-client-libraries ci/cd after building base-notebook.

> Actually it's too dangerous: if the rs-client-libraries ci/cd is already running, the two runs would overwrite each other's docker images and the result would be unstable.

Before rs-workflow-env triggers rs-client-libraries, it cancels active workflow runs with the same branch name.